### PR TITLE
Do not explicitly specify target framework for LSP build

### DIFF
--- a/Build-LSP-dev.ps1
+++ b/Build-LSP-dev.ps1
@@ -4,5 +4,5 @@ $serverRoot = Join-Path $PSScriptRoot 'lib\server'
 $publishRoot = Join-Path $PSScriptRoot 'out'
 
 & $dotnet restore "$serverRoot\MSBuildProjectTools.sln"
-& $dotnet publish "$serverRoot\src\LanguageServer\LanguageServer.csproj" -f net6.0 -o "$publishRoot\language-server"
-& $dotnet publish "$serverRoot\src\LanguageServer.TaskReflection\LanguageServer.TaskReflection.csproj" -f net6.0 -o "$publishRoot\task-reflection"
+& $dotnet publish "$serverRoot\src\LanguageServer\LanguageServer.csproj" -o "$publishRoot\language-server"
+& $dotnet publish "$serverRoot\src\LanguageServer.TaskReflection\LanguageServer.TaskReflection.csproj" -o "$publishRoot\task-reflection"

--- a/Build-LanguageServer.ps1
+++ b/Build-LanguageServer.ps1
@@ -12,5 +12,5 @@ $serverRoot = Join-Path $PSScriptRoot 'lib\server'
 $publishRoot = Join-Path $PSScriptRoot 'out'
 
 & $dotnet restore "$serverRoot\MSBuildProjectTools.sln" /p:VersionPrefix="$VersionPrefix" /p:VersionSuffix="$($VersionSuffix)"
-& $dotnet publish "$serverRoot\src\LanguageServer\LanguageServer.csproj" -f net6.0 -o "$publishRoot\language-server" /p:VersionPrefix="$VersionPrefix" /p:VersionSuffix="$($VersionSuffix)"
-& $dotnet publish "$serverRoot\src\LanguageServer.TaskReflection\LanguageServer.TaskReflection.csproj" -f net6.0 -o "$publishRoot\task-reflection" /p:VersionPrefix="$VersionPrefix" /p:VersionSuffix="$($VersionSuffix)"
+& $dotnet publish "$serverRoot\src\LanguageServer\LanguageServer.csproj" -o "$publishRoot\language-server" /p:VersionPrefix="$VersionPrefix" /p:VersionSuffix="$($VersionSuffix)"
+& $dotnet publish "$serverRoot\src\LanguageServer.TaskReflection\LanguageServer.TaskReflection.csproj" -o "$publishRoot\task-reflection" /p:VersionPrefix="$VersionPrefix" /p:VersionSuffix="$($VersionSuffix)"

--- a/build-language-server.sh
+++ b/build-language-server.sh
@@ -15,5 +15,5 @@ ServerRoot="$PWD/lib/server"
 PublishRoot="$PWD/out"
 
 dotnet restore "$ServerRoot/MSBuildProjectTools.sln" /p:VersionPrefix="$VersionPrefix" /p:VersionSuffix="$VersionSuffix"
-dotnet publish "$ServerRoot/src/LanguageServer/LanguageServer.csproj" -f net6.0 -o "$PublishRoot/language-server" /p:VersionPrefix="$VersionPrefix" /p:VersionSuffix="$VersionSuffix"
-dotnet publish "$ServerRoot/src/LanguageServer.TaskReflection/LanguageServer.TaskReflection.csproj" -f net6.0 -o "$PublishRoot/task-reflection" /p:VersionPrefix="$VersionPrefix" /p:VersionSuffix="$VersionSuffix"
+dotnet publish "$ServerRoot/src/LanguageServer/LanguageServer.csproj" -o "$PublishRoot/language-server" /p:VersionPrefix="$VersionPrefix" /p:VersionSuffix="$VersionSuffix"
+dotnet publish "$ServerRoot/src/LanguageServer.TaskReflection/LanguageServer.TaskReflection.csproj" -o "$PublishRoot/task-reflection" /p:VersionPrefix="$VersionPrefix" /p:VersionSuffix="$VersionSuffix"


### PR DESCRIPTION
Since LSP is built only for 1 target framework, we don't actually need to specify it in command line arguments. So when time comes to update to newer TFM, we have less places to change