### PR TITLE
Bump target for typescript compiler

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,11 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es6",
+        "target": "es2017",
         "noImplicitAny": false,
         "outDir": "out",
         "lib": [
-            "es6", "dom"
+            "es2017", "dom"
         ],
         "sourceMap": true,
         "rootDir": "."


### PR DESCRIPTION
`es2017` has proper `await` support, so it doesn't need to generate polyfills for it. This reduces pure js output size from ~29KB to ~24KB. Yes, it is not much, but it is basically for free. We are safe to make this change since we now target VS Code engine 1.72+ which 100% has required runtime capabilities