### PR TITLE
Remove DOM lib from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
         "noImplicitAny": false,
         "outDir": "out",
         "lib": [
-            "es2017", "dom"
+            "es2017"
         ],
         "sourceMap": true,
         "rootDir": "."


### PR DESCRIPTION
There is no direct access to DOM in a VS Code extension