### PR TITLE
Clear script section in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -217,8 +217,7 @@
     },
     "scripts": {
         "vscode:prepublish": "tsc -p ./",
-        "compile": "tsc -watch -p ./",
-        "test": "node ./node_modules/vscode/bin/test"
+        "compile": "tsc -p ./"
     },
     "extensionDependencies": [
         "ms-dotnettools.vscode-dotnet-runtime"


### PR DESCRIPTION
1. There are no tests, so removed `test` script
2. `compile` script is used to launch extension when debugging. But since there are more changes to the language server, the `-watch` option is not helpful and even sometimes harmful considering that I need to manually stop it to rebuild and pick up LSP changes