### PR TITLE
Remove note about requiring .NET 6 to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ An extension for VS Code that provides intellisense for MSBuild project files, i
 
 The language service used by this extension can be found here: [tintoy/msbuild-project-tools-server](https://github.com/tintoy/msbuild-project-tools-server/)
 
-**Note**: You will need the .NET Core **runtime v6.0.0 (or SDK v6.0.100) or newer** installed to use the language service (but your projects can target any version you have installed).
-
 ## Usage
 
 * Completions for `PackageReference` and `DotNetCliToolReference`.


### PR DESCRIPTION
After merging task scanning to be in-process work we now don't spawn any additional processes for us (except checking installed .NET version on user's machine, but it is obviously intended to use any .NET version). Since starting LSP is done using isolated runtime from .NET Runtime extension, we do not require end user to have any specific version of .NET to be installed anymore