### PR TITLE
Add F# project files to the list of msbuild extensions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,6 +207,7 @@
                 ],
                 "extensions": [
                     "csproj",
+                    "fsproj",
                     "props",
                     "targets",
                     "msbuild"


### PR DESCRIPTION
see also: https://github.com/ionide/ionide-vscode-fsharp/issues/1917

I hope that't basically it for binding .fsproj files to this extension. I didn't test it TBH.