### PR TITLE
Remove C#-specific option from editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,5 +10,3 @@ insert_final_newline = true
 
 [*.yml]
 indent_size = 2
-
-csharp_style_throw_expression = false:none


### PR DESCRIPTION
This repo no longer contains any C# code, so the option is redundant