### PR TITLE
Enable all kinds of completions by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,9 @@
                     "default": [
                         "ItemType",
                         "ItemMetadata",
-                        "Property"
+                        "Property",
+                        "Target",
+                        "Task"
                     ],
                     "description": "Types of objects defined in the current project to include when offering completions."
                 },


### PR DESCRIPTION
Since target/task completions no longer cause perf problems as they are moved to in-process handling, we should enable them by default. Users can opt out if necessary. In the long run, I believe, we should remove this option entirely (imagine if C# had such option for every type of completions and some of them were off by default). But it should stay for at least 1 release, so if there are problems with it, we can guide users to disable these types of completions and fix the underlying issue.