### PR TITLE
Remove `CONTRIBUTORS.md`

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,6 +1,0 @@
-# Contributors
-
-* Adam Friedman (@tintoy)
-* Will 保哥 (@doggy8088)
-* Yusuke Ito (@itn3000)
-* Ilja Nosik (@inosik)


### PR DESCRIPTION
Github already shows all contributors, there is not need for us to store them separately
![firefox_EgEhM5yRWQ](https://github.com/tintoy/msbuild-project-tools-vscode/assets/70431552/beb7879c-d8f7-4bcd-a7da-bf13f45ebfd5)
