### PR TITLE
Update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,17 +10,17 @@
             "license": "MIT",
             "dependencies": {
                 "object-path": "^0.11.8",
-                "vscode-languageclient": "^5.2.1"
+                "vscode-languageclient": "^7.0.0"
             },
             "devDependencies": {
-                "@types/node": "^6.0.40",
+                "@types/node": "^18.15.0",
                 "@types/object-path": "^0.11.1",
-                "@types/vscode": "^1.72.0",
+                "@types/vscode": "^1.82.0",
                 "tslint": "^5.20.0",
                 "typescript": "^4.1.6"
             },
             "engines": {
-                "vscode": "^1.72.0"
+                "vscode": "^1.82.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -60,10 +60,13 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "6.14.13",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.13.tgz",
-            "integrity": "sha512-J1F0XJ/9zxlZel5ZlbeSuHW2OpabrUAqpFuC2sm2I3by8sERQ8+KCjNKUcq8QHuzpGMWiJpo9ZxeHrqrP2KzQw==",
-            "dev": true
+            "version": "18.18.7",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.7.tgz",
+            "integrity": "sha512-bw+lEsxis6eqJYW8Ql6+yTqkE6RuFtsQPSe5JxXbqYRFQEER5aJA9a5UH9igqDWm3X4iLHIKOHlnAXLM4mi7uQ==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
         },
         "node_modules/@types/object-path": {
             "version": "0.11.1",
@@ -72,9 +75,9 @@
             "dev": true
         },
         "node_modules/@types/vscode": {
-            "version": "1.81.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.81.0.tgz",
-            "integrity": "sha512-YIaCwpT+O2E7WOMq0eCgBEABE++SX3Yl/O02GoMIF2DO3qAtvw7m6BXFYsxnc6XyzwZgh6/s/UG78LSSombl2w==",
+            "version": "1.83.1",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.83.1.tgz",
+            "integrity": "sha512-BHu51NaNKOtDf3BOonY3sKFFmZKEpRkzqkZVpSYxowLbs5JqjOQemYFob7Gs5rpxE5tiGhfpnMpcdF/oKrLg4w==",
             "dev": true
         },
         "node_modules/ansi-styles": {
@@ -101,14 +104,12 @@
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -161,8 +162,7 @@
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "dev": true
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
         },
         "node_modules/diff": {
             "version": "4.0.2",
@@ -295,11 +295,21 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
+        "node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/minimatch": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-            "dev": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -381,6 +391,7 @@
             "version": "5.7.2",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
             "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+            "dev": true,
             "bin": {
                 "semver": "bin/semver"
             }
@@ -476,45 +487,71 @@
                 "node": ">=4.2.0"
             }
         },
+        "node_modules/undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "dev": true
+        },
         "node_modules/vscode-jsonrpc": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
-            "integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+            "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
             "engines": {
                 "node": ">=8.0.0 || >=10.0.0"
             }
         },
         "node_modules/vscode-languageclient": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-5.2.1.tgz",
-            "integrity": "sha512-7jrS/9WnV0ruqPamN1nE7qCxn0phkH5LjSgSp9h6qoJGoeAKzwKz/PF6M+iGA/aklx4GLZg1prddhEPQtuXI1Q==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
+            "integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
             "dependencies": {
-                "semver": "^5.5.0",
-                "vscode-languageserver-protocol": "3.14.1"
+                "minimatch": "^3.0.4",
+                "semver": "^7.3.4",
+                "vscode-languageserver-protocol": "3.16.0"
             },
             "engines": {
-                "vscode": "^1.30"
+                "vscode": "^1.52.0"
+            }
+        },
+        "node_modules/vscode-languageclient/node_modules/semver": {
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/vscode-languageserver-protocol": {
-            "version": "3.14.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz",
-            "integrity": "sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==",
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+            "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
             "dependencies": {
-                "vscode-jsonrpc": "^4.0.0",
-                "vscode-languageserver-types": "3.14.0"
+                "vscode-jsonrpc": "6.0.0",
+                "vscode-languageserver-types": "3.16.0"
             }
         },
         "node_modules/vscode-languageserver-types": {
-            "version": "3.14.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz",
-            "integrity": "sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A=="
+            "version": "3.16.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+            "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
         },
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "dev": true
+        },
+        "node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "object-path": "^0.11.8",
-                "vscode-languageclient": "^7.0.0"
+                "vscode-languageclient": "^9.0.1"
             },
             "devDependencies": {
                 "@types/node": "^18.15.0",
@@ -110,6 +110,7 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -162,7 +163,8 @@
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "dev": true
         },
         "node_modules/diff": {
             "version": "4.0.2",
@@ -310,6 +312,7 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -494,24 +497,43 @@
             "dev": true
         },
         "node_modules/vscode-jsonrpc": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-            "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+            "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
             "engines": {
-                "node": ">=8.0.0 || >=10.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/vscode-languageclient": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
-            "integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+            "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
             "dependencies": {
-                "minimatch": "^3.0.4",
-                "semver": "^7.3.4",
-                "vscode-languageserver-protocol": "3.16.0"
+                "minimatch": "^5.1.0",
+                "semver": "^7.3.7",
+                "vscode-languageserver-protocol": "3.17.5"
             },
             "engines": {
-                "vscode": "^1.52.0"
+                "vscode": "^1.82.0"
+            }
+        },
+        "node_modules/vscode-languageclient/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/vscode-languageclient/node_modules/minimatch": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/vscode-languageclient/node_modules/semver": {
@@ -529,18 +551,18 @@
             }
         },
         "node_modules/vscode-languageserver-protocol": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-            "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+            "version": "3.17.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+            "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
             "dependencies": {
-                "vscode-jsonrpc": "6.0.0",
-                "vscode-languageserver-types": "3.16.0"
+                "vscode-jsonrpc": "8.2.0",
+                "vscode-languageserver-types": "3.17.5"
             }
         },
         "node_modules/vscode-languageserver-types": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-            "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+            "version": "3.17.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+            "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
         },
         "node_modules/wrappy": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     },
     "icon": "images/icon.png",
     "engines": {
-        "vscode": "^1.72.0"
+        "vscode": "^1.82.0"
     },
     "categories": [
         "Programming Languages",
@@ -34,7 +34,6 @@
         "workspaceContains:**/*.*proj",
         "workspaceContains:**/*.props",
         "workspaceContains:**/*.targets",
-        "onLanguage:msbuild",
         "onLanguage:xml"
     ],
     "main": "./out/src/extension/extension",
@@ -226,14 +225,14 @@
         "ms-dotnettools.vscode-dotnet-runtime"
     ],
     "devDependencies": {
-        "@types/node": "^6.0.40",
+        "@types/node": "^18.15.0",
         "@types/object-path": "^0.11.1",
-        "@types/vscode": "^1.72.0",
+        "@types/vscode": "^1.82.0",
         "tslint": "^5.20.0",
         "typescript": "^4.1.6"
     },
     "dependencies": {
         "object-path": "^0.11.8",
-        "vscode-languageclient": "^5.2.1"
+        "vscode-languageclient": "^7.0.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -233,6 +233,6 @@
     },
     "dependencies": {
         "object-path": "^0.11.8",
-        "vscode-languageclient": "^7.0.0"
+        "vscode-languageclient": "^9.0.1"
     }
 }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -2,8 +2,9 @@
 
 import { exec } from 'child_process';
 import * as vscode from 'vscode';
-import { LanguageClient, ServerOptions, LanguageClientOptions, ErrorAction, CloseAction, RevealOutputChannelOn } from 'vscode-languageclient';
-import { Trace } from 'vscode-jsonrpc/lib/main';
+import { LanguageClientOptions, ErrorAction, CloseAction, RevealOutputChannelOn } from 'vscode-languageclient';
+import { LanguageClient, ServerOptions } from 'vscode-languageclient/lib/node/main';
+import { Trace } from 'vscode-jsonrpc/lib/node/main';
 
 import * as dotnet from './utils/dotnet';
 import { handleBusyNotifications } from './notifications';

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -2,7 +2,7 @@
 
 import { exec } from 'child_process';
 import * as vscode from 'vscode';
-import { LanguageClientOptions, ErrorAction, CloseAction, RevealOutputChannelOn } from 'vscode-languageclient';
+import { LanguageClientOptions, ErrorAction, CloseAction, RevealOutputChannelOn, CloseHandlerResult } from 'vscode-languageclient';
 import { LanguageClient, ServerOptions } from 'vscode-languageclient/lib/node/main';
 import { Trace } from 'vscode-jsonrpc/lib/node/main';
 
@@ -70,11 +70,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             await loadConfiguration();
 
             if (languageClient) {
-                if (configuration.logging.trace) {
-                    languageClient.trace = Trace.Verbose;
-                } else {
-                    languageClient.trace = Trace.Off;
-                }
+                const trace = configuration.logging.trace ? Trace.Verbose : Trace.Off;
+                await languageClient.setTrace(trace);
             }
         })
     );
@@ -83,8 +80,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 /**
  * Called when the extension is deactivated.
  */
-export function deactivate(): void {
-    // Nothing to clean up.
+export async function deactivate(): Promise<void> {
+    await languageClient.stop();
 }
 
 /**
@@ -131,7 +128,7 @@ async function createLanguageClient(context: vscode.ExtensionContext, dotnetExec
         errorHandler: {
             error: (error, message, count) => {
                 if (count > 2)  // Don't be annoying
-                    return ErrorAction.Shutdown;
+                    return { action: ErrorAction.Shutdown };
 
                 console.log(message);
                 console.log(error);
@@ -141,9 +138,9 @@ async function createLanguageClient(context: vscode.ExtensionContext, dotnetExec
                 else
                     outputChannel.appendLine(`The MSBuild language server encountered an unexpected error.\n\n${error}`);
 
-                return ErrorAction.Continue;
+                return { action: ErrorAction.Continue };
             },
-            closed: () => CloseAction.DoNotRestart
+            closed: () => { return { action: CloseAction.DoNotRestart } }
         },
         initializationFailedHandler(error: Error) : boolean {
             console.log(error);
@@ -190,32 +187,15 @@ async function createLanguageClient(context: vscode.ExtensionContext, dotnetExec
     };
 
     languageClient = new LanguageClient('MSBuild Language Service', serverOptions, clientOptions);
-    if (configuration.logging.trace) {
-        languageClient.trace = Trace.Verbose;
-    } else {
-        languageClient.trace = Trace.Off;
-    }
+    const trace = configuration.logging.trace ? Trace.Verbose : Trace.Off;
+    await languageClient.setTrace(trace);
 
-    handleBusyNotifications(languageClient, statusBarItem);
-
-    let languageClientDisposal : vscode.Disposable;
     try {
-        languageClientDisposal = languageClient.start();
-        context.subscriptions.push(languageClientDisposal);
+        await languageClient.start();
+        handleBusyNotifications(languageClient, statusBarItem);
     }
     catch (startFailed) {
         outputChannel.appendLine(`Failed to start MSBuild language service.\n\n${startFailed}`);
-        languageClientDisposal.dispose();
-
-        return;
-    }
-
-    try {
-        await languageClient.onReady();
-    } catch (onReadyFailed) {
-        outputChannel.appendLine(`Failed to start MSBuild language server.\n\n${onReadyFailed}`);
-        languageClientDisposal.dispose();
-
         return;
     }
 

--- a/src/extension/notifications.ts
+++ b/src/extension/notifications.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { NotificationType } from 'vscode-jsonrpc';
-import { LanguageClient } from 'vscode-languageclient/lib/main';
+import { LanguageClient } from 'vscode-languageclient/lib/node/main';
 
 /**
  * Represents a custom notification indicating that the MSBuild language service is or is not busy.
@@ -18,7 +18,7 @@ export interface BusyNotification {
  */
 export namespace NotificationTypes {
     /** The {@link BusyNotification} type. */
-    export const busy = new NotificationType<BusyNotification, void>('msbuild/busy');
+    export const busy = new NotificationType<BusyNotification>('msbuild/busy');
 }
 
 /**

--- a/src/extension/notifications.ts
+++ b/src/extension/notifications.ts
@@ -27,17 +27,15 @@ export namespace NotificationTypes {
  * @param languageClient The MSBuild language client.
  */
 export function handleBusyNotifications(languageClient: LanguageClient, statusBarItem: vscode.StatusBarItem): void {
-    languageClient.onReady().then(() => {
-        languageClient.onNotification(NotificationTypes.busy, notification => {
-            if (notification.isBusy) {
-                statusBarItem.text = '$(watch) MSBuild Project';
-                statusBarItem.tooltip = 'MSBuild Project Tools: ' + notification.message;
-                statusBarItem.show();
-            } else {
-                statusBarItem.text = '$(check) MSBuild Project';
-                statusBarItem.tooltip = 'MSBuild Project Tools';
-                statusBarItem.hide();
-            }
-        });
+    languageClient.onNotification(NotificationTypes.busy, notification => {
+        if (notification.isBusy) {
+            statusBarItem.text = '$(watch) MSBuild Project';
+            statusBarItem.tooltip = 'MSBuild Project Tools: ' + notification.message;
+            statusBarItem.show();
+        } else {
+            statusBarItem.text = '$(check) MSBuild Project';
+            statusBarItem.tooltip = 'MSBuild Project Tools';
+            statusBarItem.hide();
+        }
     });
 }


### PR DESCRIPTION
The goal was to update `vscode-languageclient` to the latest version. However, the latest version requires vscode 1.82+, so updated it as well. There were breaking changes, so quite a bit of code changed. Verified manually that extension still works (our client side code it there for the most part to start a language server, thus the fact, that extension still correctly boots is an acceptable verification IMO)