### PR TITLE
Basic integration with redhat.xml extension for `msbuild` language

### DIFF
--- a/package.json
+++ b/package.json
@@ -215,6 +215,11 @@
                 ],
                 "configuration": "./language-configuration.json"
             }
+        ],
+        "xmlLanguageParticipants": [
+            {
+                "languageId": "msbuild"
+            }
         ]
     },
     "scripts": {


### PR DESCRIPTION
Fixes: https://github.com/tintoy/msbuild-project-tools-vscode/issues/108

This is the easiest thing we can do to integrate with redhat's extension. We just tell their extension, that `msbuild` is a valid xml language, so their language server can provide features to it.

Before (features from both extensions work correctly, but as soon as I switch to `msbuild` language, we loose all features from redhat's extension):
![Code_4ydMgEGSZL](https://github.com/tintoy/msbuild-project-tools-vscode/assets/70431552/d7c4a3ed-e221-49c5-a69f-c5198c9570a7)

After (we can feature from both extensions in both `xml` and `msbuild` language):
![Code_C01FlwCvxI](https://github.com/tintoy/msbuild-project-tools-vscode/assets/70431552/19f30ea7-8619-4c4d-815c-86cfd83a06ad)
