### PR TITLE
Remove language server probing

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import { realpathSync } from "fs";
+import { realpathSync } from 'fs';
 import * as vscode from 'vscode';
 import * as which from 'which';
 import { LanguageClientOptions, ErrorAction, CloseAction, RevealOutputChannelOn } from 'vscode-languageclient';


### PR DESCRIPTION
Client side of https://github.com/tintoy/msbuild-project-tools-vscode/issues/140
Closes https://github.com/tintoy/msbuild-project-tools-vscode/issues/140

I think, we also should release a new `0.6.0` version after this PR. The changelog can be:
- Isolated runtime for the language server is back meaning you are no longer required to have a specified version of .NET to be installed to be able to use the extension
- Language server now runs on .NET 8
- Extension startup time has been improved

The reason for the change is to separate runtime isolation into its own release. We've already seen that this change is risky and it's better if we catch any left over problems with it now rather than when this change will be surrounded by other changes in the changelog list