### PR TITLE
Initial support for overriding global MSBuild properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,11 @@
                     "default": null,
                     "description": "Override the MSBuildExtensionsPath32 property."
                 },
+                "msbuildProjectTools.msbuild.globalProperties": {
+                    "type": "object",
+                    "default": {},
+                    "description": "Override the default MSBuild properties used when a project is first loaded."
+                },
                 "msbuildProjectTools.experimentalFeatures": {
                     "type": "array",
                     "items": {


### PR DESCRIPTION
This is the VSCode-extension component of tintoy/msbuild-project-tools-vscode#166:

Add an extension-level configuration option `msbuildProjectTools.msbuild.globalProperties` (type: `object`) used to configure overrides of the default MSBuild properties used before a project is loaded.

Note that, by design, this option is selectively overridden by more-specific property overrides (such as `msbuildProjectTools.msbuild.extensionsPath` and `msbuildProjectTools.msbuild.extensionsPath32`).
