### PR TITLE
Implement VSCode variable expansion for global properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
                 "msbuildProjectTools.msbuild.globalProperties": {
                     "type": "object",
                     "default": {},
-                    "description": "Override the default MSBuild properties used when a project is first loaded."
+                    "description": "Override the default MSBuild properties used when a project is first loaded. Values support ${workspaceFolder}, ${workspaceFolderBasename}, ${workspaceRoot}, ${workspaceRootFolderName}, ${userHome}, ${pathSeparator}, and ${env:Name}."
                 },
                 "msbuildProjectTools.experimentalFeatures": {
                     "type": "array",
@@ -197,7 +197,8 @@
         "vscode:prepublish": "npm run build-production",
         "build-language-server": "powershell ./Publish-LanguageServer.ps1",
         "build-dev": "webpack --mode development",
-        "build-production": "webpack --mode production"
+        "build-production": "webpack --mode production",
+        "test": "tsc && node --test src/*.test.js"
     },
     "extensionDependencies": [
         "ms-dotnettools.vscode-dotnet-runtime"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import { Trace } from 'vscode-jsonrpc/lib/node/main';
 import * as dotnet from './dotnet';
 import { handleBusyNotifications } from './notifications';
 import { registerInternalCommands } from './internal-commands';
+import { expandVSCodeVariables, VariableExpansionContext } from './variable-expansion';
 
 let languageClient: LanguageClient;
 let statusBarItem: vscode.StatusBarItem;
@@ -72,8 +73,52 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
                 const trace = vscode.workspace.getConfiguration('msbuildProjectTools.logging').trace ? Trace.Verbose : Trace.Off;
                 await languageClient.setTrace(trace);
             }
+
+            if (languageClient && args.affectsConfiguration('msbuildProjectTools')) {
+                await languageClient.sendNotification('workspace/didChangeConfiguration', {
+                    settings: getLanguageServerConfiguration()
+                });
+            }
         })
     );
+}
+
+/**
+ * Get the current language-server configuration, expanding variables supported
+ * in MSBuild global-property overrides.
+ */
+function getLanguageServerConfiguration(): any {
+    const settings = vscode.workspace.getConfiguration().get<any>('msbuildProjectTools', {});
+    const variableExpansionContext: VariableExpansionContext = {
+        environment: process.env,
+        userHome: process.env.USERPROFILE || process.env.HOME,
+        workspaceFolders: (vscode.workspace.workspaceFolders || []).map(folder => ({
+            name: folder.name,
+            path: folder.uri.fsPath
+        }))
+    };;
+
+    const globalProperties = settings?.msbuild?.globalProperties;
+    if (!globalProperties || typeof globalProperties !== 'object')
+        return settings; // For now, this function is only interested in modifying msbuildProjectTools.msbuild.globalProperties. If that doesn't exist, just return the original settings.
+
+    const expandedGlobalProperties: { [name: string]: unknown } = {};
+    for (const propertyName of Object.keys(globalProperties)) {
+        const propertyValue = globalProperties[propertyName];
+        expandedGlobalProperties[propertyName] = typeof propertyValue === 'string'
+            ? expandVSCodeVariables(propertyValue, variableExpansionContext)
+            : propertyValue;
+    }
+
+    return {
+        msbuildProjectTools: {
+            ...settings,
+            msbuild: {
+                ...settings.msbuild,
+                globalProperties: expandedGlobalProperties,
+            }
+        }
+    };
 }
 
 /**
@@ -100,9 +145,7 @@ async function createLanguageClient(context: vscode.ExtensionContext, dotnetOnHo
     outputChannel.appendLine('Starting MSBuild language service...');
 
     const clientOptions: LanguageClientOptions = {
-        synchronize: {
-            configurationSection: 'msbuildProjectTools'
-        },
+        initializationOptions: getLanguageServerConfiguration(),
         diagnosticCollectionName: 'MSBuild Project',
         errorHandler: {
             error: (error, message, count) => {

--- a/src/variable-expansion.test.js
+++ b/src/variable-expansion.test.js
@@ -17,20 +17,17 @@ const context = {
 };
 
 test('expands workspace variables and legacy aliases', () => {
-    assert.equal(
-        expandVSCodeVariables('${workspaceFolder}/Foo.sln', context),
-        'C:\\src\\main/Foo.sln'
-    );
-    assert.equal(expandVSCodeVariables('${workspaceRoot}', context), 'C:\\src\\main');
+    assert.equal(expandVSCodeVariables('${workspaceFolder}/Foo.sln', context), 'C:\\src\\main/Foo.sln');
+    assert.equal(expandVSCodeVariables('${workspaceRoot}',           context), 'C:\\src\\main');
     assert.equal(expandVSCodeVariables('${workspaceFolderBasename}', context), 'Main');
     assert.equal(expandVSCodeVariables('${workspaceRootFolderName}', context), 'Main');
 });
 
 test('expands named workspace, environment, and host variables', () => {
-    assert.equal(expandVSCodeVariables('${workspaceFolder:Shared}', context), 'C:\\src\\shared');
+    assert.equal(expandVSCodeVariables('${workspaceFolder:Shared}',  context), 'C:\\src\\shared');
     assert.equal(expandVSCodeVariables('${env:BUILD_CONFIGURATION}', context), 'Release');
-    assert.equal(expandVSCodeVariables('${userHome}', context), 'C:\\Users\\test');
-    assert.equal(expandVSCodeVariables('${pathSeparator}', context), path.sep);
+    assert.equal(expandVSCodeVariables('${userHome}',                context), 'C:\\Users\\test');
+    assert.equal(expandVSCodeVariables('${pathSeparator}',           context), path.sep);
 });
 
 test('recursively expands variables while safely stopping cycles', () => {
@@ -44,11 +41,14 @@ test('recursively expands variables while safely stopping cycles', () => {
     };
 
     assert.equal(expandVSCodeVariables('${env:ROOT}/Foo.sln', recursiveContext), 'C:\\src\\main/Foo.sln');
-    assert.equal(expandVSCodeVariables('${env:FIRST}', recursiveContext), '${env:FIRST}');
+
+    // There is no right answer for this test between FIRST/SECOND, recursion depth is arbitrarily set to 10 atow.
+    const result = expandVSCodeVariables('${env:FIRST}', recursiveContext);
+    assert([ '${env:FIRST}', '${env:SECOND}' ].includes(result));
 });
 
 test('leaves unsupported and unavailable variables unchanged', () => {
-    assert.equal(expandVSCodeVariables('${command:chooseFolder}', context), '${command:chooseFolder}');
+    assert.equal(expandVSCodeVariables('${command:chooseFolder}',    context), '${command:chooseFolder}');
     assert.equal(expandVSCodeVariables('${workspaceFolder:Missing}', context), '${workspaceFolder:Missing}');
-    assert.equal(expandVSCodeVariables('${env:MISSING}', context), '${env:MISSING}');
+    assert.equal(expandVSCodeVariables('${env:MISSING}',             context), '${env:MISSING}');
 });

--- a/src/variable-expansion.test.js
+++ b/src/variable-expansion.test.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const test = require('node:test');
+const { expandVSCodeVariables } = require('../out/variable-expansion');
+
+const context = {
+    environment: {
+        BUILD_CONFIGURATION: 'Release'
+    },
+    userHome: 'C:\\Users\\test',
+    workspaceFolders: [
+        { name: 'Main', path: 'C:\\src\\main' },
+        { name: 'Shared', path: 'C:\\src\\shared' }
+    ]
+};
+
+test('expands workspace variables and legacy aliases', () => {
+    assert.equal(
+        expandVSCodeVariables('${workspaceFolder}/Foo.sln', context),
+        'C:\\src\\main/Foo.sln'
+    );
+    assert.equal(expandVSCodeVariables('${workspaceRoot}', context), 'C:\\src\\main');
+    assert.equal(expandVSCodeVariables('${workspaceFolderBasename}', context), 'Main');
+    assert.equal(expandVSCodeVariables('${workspaceRootFolderName}', context), 'Main');
+});
+
+test('expands named workspace, environment, and host variables', () => {
+    assert.equal(expandVSCodeVariables('${workspaceFolder:Shared}', context), 'C:\\src\\shared');
+    assert.equal(expandVSCodeVariables('${env:BUILD_CONFIGURATION}', context), 'Release');
+    assert.equal(expandVSCodeVariables('${userHome}', context), 'C:\\Users\\test');
+    assert.equal(expandVSCodeVariables('${pathSeparator}', context), path.sep);
+});
+
+test('recursively expands variables while safely stopping cycles', () => {
+    const recursiveContext = {
+        ...context,
+        environment: {
+            ROOT: '${workspaceFolder}',
+            FIRST: '${env:SECOND}',
+            SECOND: '${env:FIRST}'
+        }
+    };
+
+    assert.equal(expandVSCodeVariables('${env:ROOT}/Foo.sln', recursiveContext), 'C:\\src\\main/Foo.sln');
+    assert.equal(expandVSCodeVariables('${env:FIRST}', recursiveContext), '${env:FIRST}');
+});
+
+test('leaves unsupported and unavailable variables unchanged', () => {
+    assert.equal(expandVSCodeVariables('${command:chooseFolder}', context), '${command:chooseFolder}');
+    assert.equal(expandVSCodeVariables('${workspaceFolder:Missing}', context), '${workspaceFolder:Missing}');
+    assert.equal(expandVSCodeVariables('${env:MISSING}', context), '${env:MISSING}');
+});

--- a/src/variable-expansion.ts
+++ b/src/variable-expansion.ts
@@ -1,0 +1,71 @@
+import * as path from 'path';
+
+/**
+ * Values used when expanding the subset of VS Code variables supported in
+ * MSBuild global-property overrides.
+ */
+export interface VariableExpansionContext {
+    environment: NodeJS.ProcessEnv;
+    userHome: string | undefined;
+    workspaceFolders: {
+        name: string;
+        path: string;
+    }[];
+}
+
+/**
+ * Expand supported VS Code variables in a string.
+ *
+ * Unsupported variables, and variables whose values cannot be determined, are
+ * left unchanged so they can be diagnosed or interpreted by another consumer.
+ */
+export function expandVSCodeVariables(value: string, context: VariableExpansionContext): string {
+    let expandedValue = value;
+    for (let i = 0; i < 10; i += 1) {
+        // Search for all elements like: "${...}", 'variableText' is the entire contents of '...'
+        const nextValue = expandedValue.replaceAll(
+            /\$\{([^}]+)\}/g,
+            (variableToken: string, variableText: string) => evaluateVariable(variableToken, variableText, context));
+        if (nextValue === expandedValue) {
+            break;
+        }
+        expandedValue = nextValue;
+    }
+
+    return expandedValue;
+}
+
+function evaluateVariable(variableToken: string, variableText: string, context: VariableExpansionContext): string {
+    const [ variableName, variableParam ] = variableText.split(':', 2);
+    const hasParam = !!variableParam;
+
+    // variableToken:   ${env:HOME}
+    // variableText:      env:HOME
+    // variableName:      env
+    // variableParam:         HOME
+
+    if (variableName === 'userHome' && !hasParam) {
+        return context.userHome || variableToken;
+    }
+    if (variableName === 'pathSeparator' && !hasParam) {
+        return path.sep;
+    }
+    if (variableName === 'env' && hasParam) {
+        const environmentVariable = context.environment[variableParam];
+        return environmentVariable === undefined ? variableToken : environmentVariable;
+    }
+
+    const getWorkspaceFolder = function(folderName: string | undefined) {
+        return folderName
+            ? context.workspaceFolders.find(folder => folder.name === folderName)
+            : context.workspaceFolders[0];
+    }
+    if (variableName === 'workspaceFolder' || variableName === 'workspaceRoot') {
+        return getWorkspaceFolder(variableParam)?.path || variableToken;
+    }
+    if (variableName === 'workspaceFolderBasename' || variableName === 'workspaceRootFolderName') {
+        return getWorkspaceFolder(variableParam)?.name || variableToken;
+    }
+
+    return variableToken;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,11 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es2017",
+        "target": "es2021",
         "noImplicitAny": false,
         "outDir": "out",
         "lib": [
-            "es2017"
+            "es2021"
         ],
         "sourceMap": true,
     },


### PR DESCRIPTION
This is for #175 

- Added a "variable-expansion" module & tests to provide VSCode-like variable expansions, including:
    - `${workspaceFolder}`
    - `${workspaceFolderBasename}`
    - `${workspaceRoot}`
    - `${workspaceRootFolderName}`
    - `${userHome}`
    - `${pathSeparator}`
    - `${env:NAME}`

I'll add some comments in-line where I think it's useful.

In response to this comment:

> Just bear in mind that it needs to keep working with the existing behaviour for clients that don't opt into variable expansion (e.g. non-VSCode clients).

This change will impact users if they have files or directories written in their configurations which contain a valid VSCode variable tag, such as `${userHome}`. It is possible, at least in Windows, to write a file with filename `${userHome}`. I don't know of a way to avoid this besides tagging user configurations on extension reload with a "v1" tag, and adding a "v2" one when first modified after that point.

# TODO

- [x] Write code
- [ ] Test extension changes (Don't know what you normally do for this)

# Disclaimer

> [!WARNING]
> I used an agent to generate the initial change. I scoured the produced code and refactored and tidied where it made sense, and I checked that all the tests made sense. However, I am not familiar with this extension nor with VSCode's LSP.